### PR TITLE
Do NOT compress module

### DIFF
--- a/kmodtool-xt_ndpi-el7.sh
+++ b/kmodtool-xt_ndpi-el7.sh
@@ -185,7 +185,7 @@ echo "Working. This may take some time ..."
 if [ -e "/boot/System.map-${verrel}${dotvariant}" ]; then
     /usr/sbin/depmod -aeF "/boot/System.map-${verrel}${dotvariant}" "${verrel}${dotvariant}" > /dev/null || :
 fi
-modules=( \$(find /lib/modules/${verrel}${dotvariant}/extra/${kmod_name} | grep '\.ko\.xz$') )
+modules=( \$(find /lib/modules/${verrel}${dotvariant}/extra/${kmod_name} | grep '\.ko$') )
 if [ -x "/sbin/weak-modules" ]; then
     printf '%s\n' "\${modules[@]}" | /sbin/weak-modules --add-modules
 fi
@@ -194,7 +194,7 @@ EOF
 
 cat <<EOF
 %preun         -n kmod-${kmod_name}${dashvariant}
-rpm -ql kmod-${kmod_name}${dashvariant}-%{version}-%{release}.$(arch) | grep '\.ko\.xz$' > /var/run/rpm-kmod-${kmod_name}${dashvariant}-modules
+rpm -ql kmod-${kmod_name}${dashvariant}-%{version}-%{release}.$(arch) | grep '\.ko$' > /var/run/rpm-kmod-${kmod_name}${dashvariant}-modules
 EOF
 
 cat <<EOF

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -71,9 +71,6 @@ do %{__perl} /usr/src/kernels/%{kversion}/scripts/sign-file \
 done
 %endif
 
-# Compress the module
-find %{buildroot}/lib/modules/%{kversion}/extra/%{kmod_name}/ -type f -name '*.ko' | xargs xz
-
 %clean
 %{__rm} -rf %{buildroot}
 


### PR DESCRIPTION
NethServer/dev#5385
weak-modules doesn't support compressed modules
xt_ndpi rebuilt with CentOS 7.4 kernel.