### PR TITLE
Update to nDPI-netfilter-2.2 and add support for kernel-3.10.0-862.el7

### DIFF
--- a/ndpi-netfilter_rhel7.5.patch
+++ b/ndpi-netfilter_rhel7.5.patch
@@ -1,0 +1,12 @@
+--- /tmp/main.c	2018-05-02 12:15:16.501596017 +0200
++++ ndpi-netfilter/src/main.c	2018-05-02 11:52:45.619628795 +0200
+@@ -53,6 +53,9 @@
+ #include "../lib/third_party/include/ndpi_patricia.h"
+ #include "../lib/third_party/include/ahocorasick.h"
+ 
++
++#define LINUX_VERSION_CODE KERNEL_VERSION(4,8,0)
++
+ /* Only for debug! */
+ 
+ //#define NDPI_IPPORT_DEBUG


### PR DESCRIPTION
To build this package `/etc/mock/nethserver-7-x86_64.cfg` should be modified to add the _cr_ repo:

```
[cr]
name=CentOS-$releasever - cr
baseurl=http://mirror.centos.org/centos/$releasever/cr/$basearch/
gpgcheck=0
enabled=1
```