### PR TITLE
Go back to nDPI-1.7

### DIFF
--- a/ndpi-netfilter_rhel7.5.patch
+++ b/ndpi-netfilter_rhel7.5.patch
@@ -1,12 +1,11 @@
 --- /tmp/main.c	2018-05-02 12:15:16.501596017 +0200
 +++ ndpi-netfilter/src/main.c	2018-05-02 11:52:45.619628795 +0200
-@@ -53,6 +53,9 @@
- #include "../lib/third_party/include/ndpi_patricia.h"
- #include "../lib/third_party/include/ahocorasick.h"
+@@ -50,6 +50,8 @@
  
-+
+ #include "ndpi_patricia.h"
+ 
 +#define LINUX_VERSION_CODE KERNEL_VERSION(4,8,0)
 +
  /* Only for debug! */
+ //#define NDPI_KERNEL_MALLOC_TRACE
  
- //#define NDPI_IPPORT_DEBUG

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -1,6 +1,6 @@
 # Define the kmod package name here.
 %define kmod_name xt_ndpi
-%define ndpi_git_ver ef2028190ec9117419a503e080fc2a0be4d3a5e0
+%define ndpi_git_ver 56393f4e40f18f2d8427d484502b4b2db4b344d7
 
 # If kversion isn't defined on the rpmbuild line, define it here.
 %{!?kversion: %define kversion 3.10.0-862.el7.%{_target_cpu}}


### PR DESCRIPTION
New nDPI-2.3 protocol names do not map exactly to old 1.7 names

After upgrade of nDPI kernel module, if the machine is rebooted, the firewall can't start because nDPI rules aren't valid.
If the rules are migrated before reboot, the shorewall template will skip all nDPI rules because protocols are invalid.
Both situations can be fixed by expanding the firewall configuration each time at reboot but this is not an acceptable solution.

NethServer/dev#5482
