### PR TITLE
Update to nDPI-netfilter-2.2 and nDPI-2.4

### DIFF
--- a/ndpi-netfilter_nethserver_id.patch
+++ b/ndpi-netfilter_nethserver_id.patch
@@ -1,0 +1,15 @@
+diff --git a/ndpi-netfilter/src/main.c b/ndpi-netfilter/src/main.c
+index 702ec5e..01cddee 100644
+--- a/ndpi-netfilter/src/main.c
++++ b/ndpi-netfilter/src/main.c
+@@ -2830,8 +2830,8 @@ static int parse_ndpi_proto(struct ndpi_net *n,char *cmd) {
+ 	if(!strcmp(hid,"init")) {
+ 		int i;
+ 		for(i=0; i < NDPI_NUM_BITS; i++) {
+-			n->mark[i].mark = i;
+-			n->mark[i].mask = 0x1ff;
++			n->mark[i].mark = i << 8;
++			n->mark[i].mask = 0xff00;
+ 		}
+ 		return 0;
+ 	}

--- a/ndpi-netfilter_rhel7.5.patch
+++ b/ndpi-netfilter_rhel7.5.patch
@@ -1,11 +1,12 @@
---- /tmp/main.c	2018-05-02 12:15:16.501596017 +0200
-+++ ndpi-netfilter/src/main.c	2018-05-02 11:52:45.619628795 +0200
-@@ -50,6 +50,8 @@
- 
- #include "ndpi_patricia.h"
+diff --git a/ndpi-netfilter/src/main.c b/ndpi-netfilter/src/main.c
+index fdd1dd7..f84cf7f 100644
+--- a/ndpi-netfilter/src/main.c
++++ b/ndpi-netfilter/src/main.c
+@@ -53,6 +53,7 @@
+ #include "../lib/third_party/include/ndpi_patricia.h"
+ #include "../lib/third_party/include/ahocorasick.h"
  
 +#define LINUX_VERSION_CODE KERNEL_VERSION(4,8,0)
-+
+ extern ndpi_protocol_match host_match[];
  /* Only for debug! */
- //#define NDPI_KERNEL_MALLOC_TRACE
  

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -1,6 +1,6 @@
 # Define the kmod package name here.
 %define kmod_name xt_ndpi
-%define ndpi_git_ver 56393f4e40f18f2d8427d484502b4b2db4b344d7
+%define ndpi_git_ver a360566135c9804b10aef5178d54a83fe2fd0cb9
 
 # If kversion isn't defined on the rpmbuild line, define it here.
 %{!?kversion: %define kversion 3.10.0-862.el7.%{_target_cpu}}
@@ -23,6 +23,7 @@ Source0: https://github.com/vel21ripn/nDPI/archive/%{ndpi_git_ver}.tar.gz
 Source5:  GPL-v2.0.txt
 Source10: kmodtool-%{kmod_name}-el7.sh
 Patch1: ndpi-netfilter_rhel7.5.patch
+Patch2: ndpi-netfilter_nethserver_id.patch
 
 # Magic hidden here.
 %{expand:%(sh %{SOURCE10} rpmtemplate %{kmod_name} %{kversion} "")}
@@ -37,7 +38,8 @@ of the same variant of the Linux kernel and not on any one specific build.
 
 %prep
 %setup -q -n nDPI-%{ndpi_git_ver}
-%patch1 -p0
+%patch1 -p1
+%patch2 -p1
 ./autogen.sh
 ( cd src/lib ; make ndpi_network_list.c.inc )
 cd ndpi-netfilter


### PR DESCRIPTION
Add support for kernel-3.10.0-862.el7
Patch for NethServer to shift marks 8 bits to the left (id=id00/ff00)
Note: NethServer supports a maximum of 255 nDPI protocols

NethServer/dev#5641