### PR TITLE
Update to nDPI-netfilter-2.2 and nDPI-2.4

### DIFF
--- a/ndpi-netfilter_nethserver_id.patch
+++ b/ndpi-netfilter_nethserver_id.patch
@@ -1,0 +1,15 @@
+diff --git a/ndpi-netfilter/src/main.c b/ndpi-netfilter/src/main.c
+index 702ec5e..01cddee 100644
+--- a/ndpi-netfilter/src/main.c
++++ b/ndpi-netfilter/src/main.c
+@@ -2830,8 +2830,8 @@ static int parse_ndpi_proto(struct ndpi_net *n,char *cmd) {
+ 	if(!strcmp(hid,"init")) {
+ 		int i;
+ 		for(i=0; i < NDPI_NUM_BITS; i++) {
+-			n->mark[i].mark = i;
+-			n->mark[i].mask = 0x1ff;
++			n->mark[i].mark = i << 8;
++			n->mark[i].mask = 0xff00;
+ 		}
+ 		return 0;
+ 	}

--- a/ndpi-netfilter_rhel7.5.patch
+++ b/ndpi-netfilter_rhel7.5.patch
@@ -1,11 +1,12 @@
---- /tmp/main.c	2018-05-02 12:15:16.501596017 +0200
-+++ ndpi-netfilter/src/main.c	2018-05-02 11:52:45.619628795 +0200
-@@ -50,6 +50,8 @@
- 
- #include "ndpi_patricia.h"
+diff --git a/ndpi-netfilter/src/main.c b/ndpi-netfilter/src/main.c
+index fdd1dd7..f84cf7f 100644
+--- a/ndpi-netfilter/src/main.c
++++ b/ndpi-netfilter/src/main.c
+@@ -53,6 +53,7 @@
+ #include "../lib/third_party/include/ndpi_patricia.h"
+ #include "../lib/third_party/include/ahocorasick.h"
  
 +#define LINUX_VERSION_CODE KERNEL_VERSION(4,8,0)
-+
+ extern ndpi_protocol_match host_match[];
  /* Only for debug! */
- //#define NDPI_KERNEL_MALLOC_TRACE
  

--- a/ndpi_issue_617_ggpht_com.patch
+++ b/ndpi_issue_617_ggpht_com.patch
@@ -1,0 +1,100 @@
+diff --git a/src/lib/ndpi_content_match.c.inc b/src/lib/ndpi_content_match.c.inc
+index d42e33a..65c393f 100644
+--- a/src/lib/ndpi_content_match.c.inc
++++ b/src/lib/ndpi_content_match.c.inc
+@@ -543,7 +543,7 @@ static ndpi_network host_protocol_list[] = {
+   { 0xC0AD4000 /* 192.173.64.0/18 */, 18, NDPI_PROTOCOL_NETFLIX },
+   { 0xC6266000 /* 198.38.96.0/19 */, 19, NDPI_PROTOCOL_NETFLIX },
+   { 0xC62D3000 /* 198.45.48.0/20 */, 20, NDPI_PROTOCOL_NETFLIX },
+-  { 0xD194D687 /* 209.148.214.135/21 */, 21, NDPI_PROTOCOL_NETFLIX }, 
++  { 0xD194D687 /* 209.148.214.135/21 */, 21, NDPI_PROTOCOL_NETFLIX },
+ 
+   /*
+     Cloudflare, Inc.
+@@ -7927,7 +7927,7 @@ static ndpi_network host_protocol_list[] = {
+     Valve Corporation (Steam)
+     origin AS32590
+   */
+-  
++
+   { 0x2D79B800 /* 45.121.184.0/22 */, 22, NDPI_PROTOCOL_STEAM },
+   { 0x670A7C00 /* 103.10.124.0/23 */, 23, NDPI_PROTOCOL_STEAM },
+   { 0x671C3600 /* 103.28.54.0/23 */, 23, NDPI_PROTOCOL_STEAM },
+@@ -7945,14 +7945,14 @@ static ndpi_network host_protocol_list[] = {
+   { 0xD040C800 /* 208.64.200.0/24 */, 24, NDPI_PROTOCOL_STEAM },
+   { 0xD040C900 /* 208.64.201.0/22 */, 22, NDPI_PROTOCOL_STEAM },
+   { 0xD04EA400 /* 208.78.164.0/22 */, 22, NDPI_PROTOCOL_STEAM },
+-  
++
+   /*
+     VidTO
+-  */  
++  */
+   { 0x51111030 /* 81.17.16.48/32 */, 32,  NDPI_PROTOCOL_VIDTO  },
+   { 0x5fb7329d /* 95.183.50.157/32 */, 32, NDPI_PROTOCOL_VIDTO },
+   { 0x577824f2 /* 87.120.36.242/32 */, 32, NDPI_PROTOCOL_VIDTO },
+-  
++
+   { 0x0, 0, 0 }
+ };
+ #endif
+@@ -8013,7 +8013,7 @@ static ndpi_network host_protocol_list[] = {
+ 
+ /* ****************************************************** */
+ 
+-/* 
++/*
+ 
+ Each part of a domain name can be no longer than 63 characters. There are no single-digit top-level domains and none contain digits. It doesn't look like ICANN will approve such domains either.
+ 
+@@ -8107,7 +8107,6 @@ ndpi_protocol_match host_match[] = {
+   { "drive.google.com",                       NULL, "drive.google" TLD,                          "GoogleDrive",      NDPI_PROTOCOL_GOOGLE_DRIVE, NDPI_PROTOCOL_CATEGORY_CLOUD, NDPI_PROTOCOL_ACCEPTABLE },
+ 
+   { "android.clients.google.com", NULL, "android\\.clients\\.google" TLD,   "PlayStore",    NDPI_PROTOCOL_PLAYSTORE, NDPI_PROTOCOL_CATEGORY_SW_UPDATE, NDPI_PROTOCOL_SAFE },
+-  { "ggpht.com", NULL, "ggpht" TLD,                                         "PlayStore",    NDPI_PROTOCOL_PLAYSTORE, NDPI_PROTOCOL_CATEGORY_SW_UPDATE, NDPI_PROTOCOL_SAFE },
+ 
+   /*
+     See https://better.fyi/trackers/
+@@ -8140,7 +8139,7 @@ ndpi_protocol_match host_match[] = {
+   { "google-analytics.", NULL, "google-analytics\\.",             "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_TRACKER_ADS },
+   { "gtv1.com", NULL, "gtv1" TLD,                                 "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_ACCEPTABLE },
+ 
+-  /* Google Hangout */ 
++  /* Google Hangout */
+   { "images2-hangout-opensocial.googleusercontent.com", NULL, "images2-hangout-opensocial\\.googleusercontent" TLD, "GoogleHangout", NDPI_PROTOCOL_HANGOUT, NDPI_PROTOCOL_CATEGORY_CHAT, NDPI_PROTOCOL_ACCEPTABLE },
+ 
+   /* Google Services */
+@@ -8166,6 +8165,7 @@ ndpi_protocol_match host_match[] = {
+   { "google.", NULL, "google" TLD,                                "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_SAFE },
+   { ".google.", NULL, NULL,                                       "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_SAFE },
+   { ".gstatic.com", NULL, "\\.gstatic" TLD,                       "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_SAFE },
++  { "ggpht.com", NULL, "ggpht" TLD,                               "Google",           NDPI_PROTOCOL_GOOGLE, NDPI_PROTOCOL_CATEGORY_WEB, NDPI_PROTOCOL_SAFE },
+ 
+   { "mail.outlook.com", NULL, "mail\\.outlook" TLD,               "Hotmail",          NDPI_PROTOCOL_HOTMAIL, NDPI_PROTOCOL_CATEGORY_MAIL, NDPI_PROTOCOL_ACCEPTABLE },
+ 
+@@ -8221,7 +8221,6 @@ ndpi_protocol_match host_match[] = {
+   { ".googlevideo.com", NULL, "\\.googlevideo" TLD,                    "YouTube",          NDPI_PROTOCOL_YOUTUBE, NDPI_PROTOCOL_CATEGORY_MEDIA, NDPI_PROTOCOL_FUN },
+   { ".ytimg.com", NULL, "\\.ytimg" TLD,                                "YouTube",          NDPI_PROTOCOL_YOUTUBE, NDPI_PROTOCOL_CATEGORY_MEDIA, NDPI_PROTOCOL_FUN },
+   { "youtube-nocookie.", NULL, "youtube-nocookie" TLD,                 "YouTube",          NDPI_PROTOCOL_YOUTUBE, NDPI_PROTOCOL_CATEGORY_MEDIA, NDPI_PROTOCOL_FUN },
+-  { "ggpht.com", NULL, "ggpht" TLD,                                    "YouTube",          NDPI_PROTOCOL_YOUTUBE, NDPI_PROTOCOL_CATEGORY_MEDIA, NDPI_PROTOCOL_FUN },
+ 
+   { ".vevo.com", NULL, "\\.vevo" TLD,                                  "Vevo",             NDPI_PROTOCOL_VEVO,    NDPI_PROTOCOL_CATEGORY_MEDIA, NDPI_PROTOCOL_FUN },
+ 
+@@ -8335,7 +8334,7 @@ ndpi_protocol_match host_match[] = {
+   { "muscdn.com", NULL, "muscdn" TLD,                                  "Musical.ly",       NDPI_PROTOCOL_MUSICALLY, NDPI_PROTOCOL_CATEGORY_SOCIAL_NETWORK, NDPI_PROTOCOL_FUN },
+   { "livelycdn.com", NULL, "livelycdn" TLD,                            "Musical.ly",       NDPI_PROTOCOL_MUSICALLY, NDPI_PROTOCOL_CATEGORY_SOCIAL_NETWORK, NDPI_PROTOCOL_FUN },
+   { "direct.ly", NULL, "direct\\.ly$",                                 "Musical.ly",       NDPI_PROTOCOL_MUSICALLY, NDPI_PROTOCOL_CATEGORY_SOCIAL_NETWORK, NDPI_PROTOCOL_FUN },
+-  
++
+   { "github.com", NULL, "github" TLD,                                  "Github",           NDPI_PROTOCOL_GITHUB, NDPI_PROTOCOL_CATEGORY_COLLABORATIVE, NDPI_PROTOCOL_ACCEPTABLE },
+   { ".github.com", NULL, "\\.github" TLD,                              "Github",           NDPI_PROTOCOL_GITHUB, NDPI_PROTOCOL_CATEGORY_COLLABORATIVE, NDPI_PROTOCOL_ACCEPTABLE },
+   { "github.io", NULL, NULL,                                           "Github",           NDPI_PROTOCOL_GITHUB, NDPI_PROTOCOL_CATEGORY_COLLABORATIVE, NDPI_PROTOCOL_ACCEPTABLE },
+@@ -8398,7 +8397,7 @@ ndpi_protocol_match host_match[] = {
+     than by protocol id. They are bound to a generic protocol (NDPI_PROTOCOL_GENERIC) and placed onto the right category
+   */
+   { "quickplay.com", NULL, "quickplay" TLD,                            "QuickPlay",        NDPI_PROTOCOL_GENERIC, NDPI_PROTOCOL_CATEGORY_STREAMING, NDPI_PROTOCOL_FUN },
+-  
++
+   { ".iqiyi.com", NULL, "\\.iqiyi" TLD,                                "iQIYI",            NDPI_PROTOCOL_GENERIC, NDPI_PROTOCOL_CATEGORY_STREAMING, NDPI_PROTOCOL_FUN },
+   { ".qiyi.com", NULL, "\\.qiyi" TLD,                                  "iQIYI",            NDPI_PROTOCOL_GENERIC, NDPI_PROTOCOL_CATEGORY_STREAMING, NDPI_PROTOCOL_FUN },
+   { ".71.am", NULL, "\\.71" TLD,                                       "iQIYI",            NDPI_PROTOCOL_GENERIC, NDPI_PROTOCOL_CATEGORY_STREAMING, NDPI_PROTOCOL_FUN },

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -6,7 +6,7 @@
 %{!?kversion: %define kversion 3.10.0-862.el7.%{_target_cpu}}
 
 Name:    %{kmod_name}-kmod
-Version: 2.0.4
+Version: 2.3.99
 Release: 1%{?dist}
 Group:   System Environment/Kernel
 License: GPLv2

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -24,6 +24,7 @@ Source5:  GPL-v2.0.txt
 Source10: kmodtool-%{kmod_name}-el7.sh
 Patch1: ndpi-netfilter_rhel7.5.patch
 Patch2: ndpi-netfilter_nethserver_id.patch
+Patch3: ndpi_issue_617_ggpht_com.patch
 
 # Magic hidden here.
 %{expand:%(sh %{SOURCE10} rpmtemplate %{kmod_name} %{kversion} "")}
@@ -40,6 +41,7 @@ of the same variant of the Linux kernel and not on any one specific build.
 %setup -q -n nDPI-%{ndpi_git_ver}
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 ./autogen.sh
 ( cd src/lib ; make ndpi_network_list.c.inc )
 cd ndpi-netfilter

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -1,6 +1,6 @@
 # Define the kmod package name here.
 %define kmod_name xt_ndpi
-%define ndpi_git_ver 56393f4e40f18f2d8427d484502b4b2db4b344d7
+%define ndpi_git_ver a360566135c9804b10aef5178d54a83fe2fd0cb9
 
 # If kversion isn't defined on the rpmbuild line, define it here.
 %{!?kversion: %define kversion 3.10.0-862.el7.%{_target_cpu}}
@@ -23,6 +23,7 @@ Source0: https://github.com/vel21ripn/nDPI/archive/%{ndpi_git_ver}.tar.gz
 Source5:  GPL-v2.0.txt
 Source10: kmodtool-%{kmod_name}-el7.sh
 Patch1: ndpi-netfilter_rhel7.5.patch
+Patch2: ndpi-netfilter_nethserver_id.patch
 
 # Magic hidden here.
 %{expand:%(sh %{SOURCE10} rpmtemplate %{kmod_name} %{kversion} "")}
@@ -37,7 +38,8 @@ of the same variant of the Linux kernel and not on any one specific build.
 
 %prep
 %setup -q -n nDPI-%{ndpi_git_ver}
-%patch1 -p0
+%patch1 -p1
+%patch2 -p1
 ./autogen.sh
 ( cd src/lib ; make ndpi_network_list.c.inc )
 cd ndpi-netfilter


### PR DESCRIPTION
Add support for kernel-3.10.0-862.el7
Patch for NethServer to shift marks 8 bits to the left (id=id00/ff00)
Note: NethServer supports a maximum of 255 nDPI protocols

NethServer/dev#5645
