### PR TITLE
spec: compile for 3.10.0-1160.6.1.el7 kernel

### DIFF
--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -1,9 +1,9 @@
 # Define the kmod package name here.
 %define kmod_name xt_ndpi
-%define ndpi_git_ver 386a76eb65856b9e8b41d742ef819f76ebd065dc
+%define ndpi_git_ver 96cf7764577603f1bd2896d414532afe625f6667
 
 # If kversion isn't defined on the rpmbuild line, define it here.
-%{!?kversion: %define kversion 3.10.0-1160.el7.%{_target_cpu}}
+%{!?kversion: %define kversion 3.10.0-1160.6.1.el7.%{_target_cpu}}
 
 Name:    %{kmod_name}-kmod
 Version: 2.8.1
@@ -14,8 +14,8 @@ Summary: %{kmod_name} kernel module(s)
 URL:     http://www.kernel.org/
 
 BuildRequires: redhat-rpm-config, perl, kernel-devel, gcc, iptables-devel, libpcap-devel, autoconf, automake, libtool
-BuildRequires: kernel = 3.10.0-1160.el7, kernel-devel = 3.10.0-1160.el7
-Requires: kernel >= 3.10.0-1160
+BuildRequires: kernel = 3.10.0-1160.6.1.el7, kernel-devel = 3.10.0-1160.6.1.el7
+Requires: kernel >= 3.10.0-1160.6.1
 ExclusiveArch: x86_64
 
 # Sources.

--- a/xt_ndpi-kmod.spec
+++ b/xt_ndpi-kmod.spec
@@ -3,7 +3,7 @@
 %define ndpi_git_ver 386a76eb65856b9e8b41d742ef819f76ebd065dc
 
 # If kversion isn't defined on the rpmbuild line, define it here.
-%{!?kversion: %define kversion 3.10.0-1062.el7.%{_target_cpu}}
+%{!?kversion: %define kversion 3.10.0-1160.el7.%{_target_cpu}}
 
 Name:    %{kmod_name}-kmod
 Version: 2.8.1
@@ -14,8 +14,8 @@ Summary: %{kmod_name} kernel module(s)
 URL:     http://www.kernel.org/
 
 BuildRequires: redhat-rpm-config, perl, kernel-devel, gcc, iptables-devel, libpcap-devel, autoconf, automake, libtool
-BuildRequires: kernel = 3.10.0-1062.el7, kernel-devel = 3.10.0-1062.el7
-Requires: kernel >= 3.10.0-1062
+BuildRequires: kernel = 3.10.0-1160.el7, kernel-devel = 3.10.0-1160.el7
+Requires: kernel >= 3.10.0-1160
 ExclusiveArch: x86_64
 
 # Sources.


### PR DESCRIPTION
This version will not work on kernel `3.10.0-1160`. Since this kernel has been already obsoleted by upstream update `3.10.0-1160.6.1`, it shouldn't be a real problem: the xt_ndpi module will require `3.10.0-1160.6.1` as minimum versions.

Let's hope something will not break on next upstream kernel update.

NethServer/dev#6341